### PR TITLE
Use async await where possible

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,16 +48,16 @@ internals.Connection.prototype.start = function () {
         if (this.settings.sentinels && this.settings.sentinels.length) {
             options.sentinels = this.settings.sentinels;
             options.name = this.settings.sentinelName;
-            client = new Redis(options);
+            client = Redis.createClient(options);
         }
         else if (this.settings.url) {
-            client = new Redis(this.settings.url, options);
+            client = Redis.createClient(this.settings.url, options);
         }
         else if (this.settings.socket) {
-            client = new Redis(this.settings.socket, options);
+            client = Redis.createClient(this.settings.socket, options);
         }
         else {
-            client = new Redis(this.settings.port, this.settings.host, options);
+            client = Redis.createClient(this.settings.port, this.settings.host, options);
         }
 
         // Listen to errors
@@ -143,8 +143,6 @@ internals.Connection.prototype.get = async function (key) {
 
 internals.Connection.prototype.set = async function (key, value, ttl) {
 
-    let cacheKey;
-
     if (!this.client) {
         throw Error('Connection not started');
     }
@@ -155,7 +153,7 @@ internals.Connection.prototype.set = async function (key, value, ttl) {
         ttl
     };
 
-    cacheKey = this.generateKey(key);
+    const cacheKey = this.generateKey(key);
 
     const stringifiedEnvelope = JSON.stringify(envelope);
 
@@ -163,16 +161,17 @@ internals.Connection.prototype.set = async function (key, value, ttl) {
 
     const ttlSec = Math.max(1, Math.floor(ttl / 1000));
     // Use 'pexpire' with ttl in Redis 2.6.0
-    return await this.client.expire(cacheKey, ttlSec);
+    return this.client.expire(cacheKey, ttlSec);
 };
 
 
-internals.Connection.prototype.drop = async function (key) {
+// Async
+internals.Connection.prototype.drop = function (key) {
 
     if (!this.client) {
         throw Error('Connection not started');
     }
-    return await this.client.del(this.generateKey(key));
+    return this.client.del(this.generateKey(key));
 };
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,16 +48,16 @@ internals.Connection.prototype.start = function () {
         if (this.settings.sentinels && this.settings.sentinels.length) {
             options.sentinels = this.settings.sentinels;
             options.name = this.settings.sentinelName;
-            client = Redis.createClient(options);
+            client = new Redis(options);
         }
         else if (this.settings.url) {
-            client = Redis.createClient(this.settings.url, options);
+            client = new Redis(this.settings.url, options);
         }
         else if (this.settings.socket) {
-            client = Redis.createClient(this.settings.socket, options);
+            client = new Redis(this.settings.socket, options);
         }
         else {
-            client = Redis.createClient(this.settings.port, this.settings.host, options);
+            client = new Redis(this.settings.port, this.settings.host, options);
         }
 
         // Listen to errors
@@ -109,88 +109,70 @@ internals.Connection.prototype.validateSegmentName = function (name) {
 };
 
 
-// Async
-internals.Connection.prototype.get = function (key) {
+internals.Connection.prototype.get = async function (key) {
 
-    return Promise.resolve()
-        .then(() => {
+    if (!this.client) {
+        throw Error('Connection not started');
+    }
 
-            if (!this.client) {
-                throw Error('Connection not started');
-            }
+    const result = await this.client.get(this.generateKey(key));
 
-            return this.client.get(this.generateKey(key));
-        })
-        .then((result) => {
+    if (!result) {
+        return null;
+    }
 
-            if (!result) {
-                return null;
-            }
+    let envelope = null;
+    try {
+        envelope = JSON.parse(result);
+    }
+    catch (err) { }   // Handled by validation below
 
-            let envelope = null;
-            try {
-                envelope = JSON.parse(result);
-            }
-            catch (err) { }   // Handled by validation below
+    if (!envelope) {
+        throw Error('Bad envelope content');
+    }
 
-            if (!envelope) {
-                throw Error('Bad envelope content');
-            }
+    if ((!envelope.item && envelope.item !== 0) ||
+        !envelope.stored) {
 
-            if ((!envelope.item && envelope.item !== 0) ||
-                !envelope.stored) {
+        throw Error('Incorrect envelope structure');
+    }
 
-                throw Error('Incorrect envelope structure');
-            }
-
-            return envelope;
-        });
+    return envelope;
 };
 
 
-// Async
-internals.Connection.prototype.set = function (key, value, ttl) {
+internals.Connection.prototype.set = async function (key, value, ttl) {
 
     let cacheKey;
 
-    return Promise.resolve()
-        .then(() => {
+    if (!this.client) {
+        throw Error('Connection not started');
+    }
 
-            if (!this.client) {
-                throw Error('Connection not started');
-            }
-            const envelope = {
-                item: value,
-                stored: Date.now(),
-                ttl
-            };
+    const envelope = {
+        item: value,
+        stored: Date.now(),
+        ttl
+    };
 
-            cacheKey = this.generateKey(key);
+    cacheKey = this.generateKey(key);
 
-            const stringifiedEnvelope = JSON.stringify(envelope);
+    const stringifiedEnvelope = JSON.stringify(envelope);
 
-            return this.client.set(cacheKey, stringifiedEnvelope);
-        })
-        .then(() => {
+    await this.client.set(cacheKey, stringifiedEnvelope);
 
-            const ttlSec = Math.max(1, Math.floor(ttl / 1000));
-            // Use 'pexpire' with ttl in Redis 2.6.0
-            return this.client.expire(cacheKey, ttlSec);
-        });
+    const ttlSec = Math.max(1, Math.floor(ttl / 1000));
+    // Use 'pexpire' with ttl in Redis 2.6.0
+    return await this.client.expire(cacheKey, ttlSec);
 };
 
 
-// Async
-internals.Connection.prototype.drop = function (key) {
+internals.Connection.prototype.drop = async function (key) {
 
-    return Promise.resolve()
-        .then(() => {
-
-            if (!this.client) {
-                throw Error('Connection not started');
-            }
-        })
-        .then(() => this.client.del(this.generateKey(key)));
+    if (!this.client) {
+        throw Error('Connection not started');
+    }
+    return await this.client.del(this.generateKey(key));
 };
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -273,9 +273,9 @@ describe('Redis', () => {
         client.stop();
 
         const key = { id: 'x', segment: 'test' };
-        await expect((() => {
+        await expect((async () => {
 
-            return client.connection.drop(key);
+            await client.connection.drop(key);
         })()).to.reject(Error, 'Connection not started');
     });
 
@@ -620,9 +620,9 @@ describe('Redis', () => {
 
             const redis = new Redis(options);
 
-            await expect((() => {
+            await expect((async () => {
 
-                return redis.get('test');
+                await redis.get('test');
             })()).to.reject(Error, 'Connection not started');
         });
 
@@ -779,9 +779,9 @@ describe('Redis', () => {
 
             const redis = new Redis(options);
 
-            await expect((() => {
+            await expect((async () => {
 
-                return redis.set('test1', 'test1', 3600);
+                await redis.set('test1', 'test1', 3600);
             })()).to.reject(Error, 'Connection not started');
         });
 
@@ -818,9 +818,9 @@ describe('Redis', () => {
 
             const redis = new Redis(options);
 
-            await expect((() => {
+            await expect((async () => {
 
-                return redis.drop('test2');
+                await redis.drop('test2');
             })()).to.reject(Error, 'Connection not started');
         });
 


### PR DESCRIPTION
Hey,

I greatly appreciate the time you invested in updated catbox-redis. I saw in the pr against the original repo that the maintainer want's a more async/await'ish style so wanted to help you out with some of my free time. Hope everything works because I don't know the internals of catbox all to well, let alone redis. But tests ran fine for me.

I also notices that `createClient` is marked as deprecated, so I replaced it with the constructor call.

Cheers!